### PR TITLE
feat: GitHub Actions CI/CD 설정 및 NCP 자동 배포 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,95 @@
+name: CI/CD Pipeline
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+      - main
+
+jobs:
+  lint-and-typecheck:
+    if: github.event.pull_request.merged == true
+    name: Code Quality Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry & Dependencies
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false
+          poetry install --with dev
+
+      - name: Run isort
+        run: isort . --check --diff
+
+      - name: Run black
+        run: black . --check --diff
+
+      - name: Run ruff
+        run: ruff .
+
+      - name: Run mypy (with stubs)
+        run: mypy . --strict
+
+  deploy-dev:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
+    name: Deploy to NCP Dev Server
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: SSH to Dev Server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEV_NCP_HOST }}
+          username: ${{ secrets.DEV_NCP_USER }}
+          key: ${{ secrets.DEV_NCP_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/your-project-folder
+            source ~/.bashrc || true
+            export PATH="$HOME/.poetry/bin:$HOME/.local/bin:$PATH"
+
+            git pull origin dev
+            poetry install --no-interaction --no-ansi
+            poetry run python manage.py migrate
+            poetry run python manage.py collectstatic --noinput
+
+            sudo systemctl restart gunicorn
+            sudo systemctl restart nginx
+
+  deploy-live:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    name: Deploy to NCP Live Server
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: SSH to Live Server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.LIVE_NCP_HOST }}
+          username: ${{ secrets.LIVE_NCP_USER }}
+          key: ${{ secrets.LIVE_NCP_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/your-project-folder
+            source ~/.bashrc || true
+            export PATH="$HOME/.poetry/bin:$HOME/.local/bin:$PATH"
+
+            git pull origin main
+            poetry install --no-interaction --no-ansi
+            poetry run python manage.py migrate
+            poetry run python manage.py collectstatic --noinput
+
+            sudo systemctl restart gunicorn
+            sudo systemctl restart nginx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.13"
+python = ">=3.11,<4.0"
 django = ">=5.2.1,<6.0.0"
 
 [build-system]


### PR DESCRIPTION
## :hash: 연관된 이슈

> #5 

## :memo: 작업 내용

- dev 브랜치에 PR 머지 시 → NCP 개발 서버에 자동으로 `git pull` 및 배포
- main 브랜치에 PR 머지 시 → NCP 라이브 서버에 자동으로 `git pull` 및 배포
- 코드 품질 검사: isort, black, ruff, mypy, django-stubs, djangorestframework-stubs 포함

### 스크린샷 (선택)

## :speech_balloon: 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
