### PR TITLE
마이페이지 메인 500 에러 방지 및 시리얼라이저 필드 수정

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -94,7 +94,7 @@ class OnboardingJobSerializer(serializers.ModelSerializer):
 # 마이페이지 메인
 class MypageMainSerializer(serializers.Serializer):
     nickname = serializers.CharField()
-    profile_img = serializers.ImageField(allow_null=True, required=False)
+    profile_img = serializers.CharField(allow_null=True, required=False)
     joined_at = serializers.DateTimeField()
     tracking_days = serializers.IntegerField()
     total_sleep_hours = serializers.FloatField()

--- a/users/services.py
+++ b/users/services.py
@@ -153,6 +153,11 @@ class SocialLoginService:
 
 
 # 마이페이지 메인 요약 정보
+from rest_framework.exceptions import PermissionDenied
+from datetime import timedelta
+from django.utils import timezone
+from django.db.models import Sum, Avg
+
 def get_mypage_main_data(user):
     # 탈퇴한 계정일 경우 마이페이지 접근 차단
     if user.status == UserStatus.WITHDRAWN:
@@ -167,7 +172,10 @@ def get_mypage_main_data(user):
         sleep_records.aggregate(total=Sum("sleep_duration"))["total"] or 0
     )
     total_sleep_hours = round(total_sleep_minutes / 60, 1)
-    average_sleep_score = sleep_records.aggregate(avg=Avg("score"))["avg"] or 0.0
+
+    # score가 모두 null일 수 있으므로 None 처리 방어
+    avg_score = sleep_records.aggregate(avg=Avg("score"))["avg"]
+    average_sleep_score = round(avg_score, 1) if avg_score is not None else 0.0
 
     # 90일치 일별 인지 점수(평균)
     today = timezone.now().date()
@@ -185,11 +193,13 @@ def get_mypage_main_data(user):
 
     return {
         "nickname": user.nickname,
-        "profile_img": user.profile_img,
-        "joined_at": user.joined_at,
+        "profile_img": (
+            user.profile_img.url if hasattr(user.profile_img, "url") else user.profile_img
+        ),
+        "joined_at": user.joined_at if user.joined_at else None,
         "tracking_days": tracking_days,
         "total_sleep_hours": total_sleep_hours,
-        "average_sleep_score": round(average_sleep_score, 1),
+        "average_sleep_score": average_sleep_score,
         "average_cognitive_score": average_cognitive_score,
     }
 

--- a/users/services.py
+++ b/users/services.py
@@ -152,11 +152,10 @@ class SocialLoginService:
         return tokens, user
 
 
+
+
 # 마이페이지 메인 요약 정보
-from rest_framework.exceptions import PermissionDenied
-from datetime import timedelta
-from django.utils import timezone
-from django.db.models import Sum, Avg
+
 
 def get_mypage_main_data(user):
     # 탈퇴한 계정일 경우 마이페이지 접근 차단
@@ -194,7 +193,9 @@ def get_mypage_main_data(user):
     return {
         "nickname": user.nickname,
         "profile_img": (
-            user.profile_img.url if hasattr(user.profile_img, "url") else user.profile_img
+            user.profile_img.url
+            if hasattr(user.profile_img, "url")
+            else user.profile_img
         ),
         "joined_at": user.joined_at if user.joined_at else None,
         "tracking_days": tracking_days,


### PR DESCRIPTION
## :hash: 연관된 이슈

> 없음

## :memo: 작업 내용

> 마이페이지 메인 응답에서 발생하던 500 에러 방지를 위해 탈퇴 유저 접근 시 PermissionDenied 처리
> `get_mypage_main_data()` 함수 내 수면/인지 통계 로직 안정화
> 시리얼라이저 `MypageMainSerializer` 수정
