### PR TITLE
fix: 프로필 이미지 파일 존재 여부 확인 후 .url 접근하도록 방어 처리

### DIFF
--- a/users/services.py
+++ b/users/services.py
@@ -1,12 +1,11 @@
 from collections import defaultdict
 from datetime import date, timedelta
 
+from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import Avg, Sum
 from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied
-from django.core.files.storage import default_storage
-
 
 from cognitive_statistics.models import (
     CognitiveResultPattern,
@@ -192,7 +191,8 @@ def get_mypage_main_data(user):
         "nickname": user.nickname,
         "profile_img": (
             user.profile_img.url
-            if hasattr(user.profile_img, "url") and default_storage.exists(user.profile_img.name)
+            if hasattr(user.profile_img, "url")
+            and default_storage.exists(user.profile_img.name)
             else str(user.profile_img) if user.profile_img else None
         ),
         "joined_at": user.joined_at if user.joined_at else None,

--- a/users/services.py
+++ b/users/services.py
@@ -5,6 +5,8 @@ from django.db import transaction
 from django.db.models import Avg, Sum
 from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied
+from django.core.files.storage import default_storage
+
 
 from cognitive_statistics.models import (
     CognitiveResultPattern,
@@ -190,8 +192,8 @@ def get_mypage_main_data(user):
         "nickname": user.nickname,
         "profile_img": (
             user.profile_img.url
-            if hasattr(user.profile_img, "url")
-            else user.profile_img
+            if hasattr(user.profile_img, "url") and default_storage.exists(user.profile_img.name)
+            else str(user.profile_img) if user.profile_img else None
         ),
         "joined_at": user.joined_at if user.joined_at else None,
         "tracking_days": tracking_days,


### PR DESCRIPTION
## :hash: 연관된 이슈

> 없음

## :memo: 작업 내용

> get_mypage_main_data 함수에서 profile_img 접근 시 .url 접근 전에 파일 존재 여부 확인
> default_storage.exists()를 사용해 안전하게 처리
> 파일이 없을 경우 문자열 그대로 반환하여 에러 방지