### PR TITLE
일/주 단위 수면 기록 리스트 응답 누락 버그 수정

### DIFF
--- a/users/services.py
+++ b/users/services.py
@@ -311,7 +311,6 @@ def get_record_day_list(user):
     return results
 
 
-
 # 주별 기록 (최근 4주)
 def get_record_week_list(user):
     # 주별 기록 조회 (4주 기준)


### PR DESCRIPTION
## :hash: 연관된 이슈

> 

## :memo: 작업 내용

> 일/주별 기록 리스트 응답에서 수면/인지 데이터가 누락되던 문제 수정
> `SleepRecord.date`의 타입 문제 또는 `None` 처리로 인해 `.get(date)` 실패하던 로직을 보완

