### PR TITLE
패턴 테스트 정확도 반환 및 관련 로직 제거

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -273,7 +273,6 @@ class MypageRecordDetailCognitiveSerializer(serializers.Serializer):
     symbol_accuracy = serializers.IntegerField()
     pattern_score = serializers.FloatField()
     pattern_count = serializers.IntegerField()
-    pattern_accuracy = serializers.IntegerField()
     pattern_time_ms = serializers.FloatField()
 
 

--- a/users/services.py
+++ b/users/services.py
@@ -10,7 +10,6 @@ from cognitive_statistics.models import (
     CognitiveResultPattern,
     CognitiveResultSRT,
     CognitiveResultSymbol,
-    CognitiveSessionProblem,
 )
 from sleep_record.models import SleepRecord
 
@@ -564,18 +563,6 @@ def get_cognitive_detail(user, date):
         else 0
     )
 
-    # 전체 문제수 (세션별)
-    session_problems = {
-        session_id: CognitiveSessionProblem.objects.filter(
-            session_id=session_id
-        ).count()
-        for session_id in session_latest
-    }
-    total_problems = sum(session_problems.values())
-    pattern_accuracy = (
-        int(min((pattern_count / total_problems) * 100, 100)) if total_problems else 0
-    )
-
     total_score = srt_score + symbol_score + pattern_score
 
     return {
@@ -586,7 +573,6 @@ def get_cognitive_detail(user, date):
         "symbol_accuracy": int(symbol_accuracy),
         "pattern_score": round(pattern_score, 1),
         "pattern_count": int(pattern_count),
-        "pattern_accuracy": int(pattern_accuracy),
         "pattern_time_ms": int(pattern_time_sec * 1000),
         "total_score": round(total_score, 1),
     }


### PR DESCRIPTION
## :hash: 연관된 이슈

> ex) #이슈번호, #이슈번호, ...

## :memo: 작업 내용

> 패턴 테스트 총 문제수가 5개로 고정되어있어서 계속 100이 넘는 숫자로 반환되는 문제 발생
> 프론트 및 백엔드끼리 서로 상의 후 패턴 테스트 정확도 삭제하기로함
> 패턴 테스트 정확도 관련 로직 전부 제거